### PR TITLE
Add eager validation for publisher and subscriber creation

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -47,7 +47,7 @@ To publish messages to Pub/Sub, you can use the `PubsubPublisher` class:
 ```scala mdoc:silent
 import fs2.pubsub._
 
-val publisher: PubSubPublisher[IO, String] = PubSubPublisher
+val publisher: IO[PubSubPublisher[IO, String]] = PubSubPublisher
     .http[IO, String]
     .projectId(ProjectId("my-project"))
     .topic(Topic("my-topic"))
@@ -61,7 +61,7 @@ Then you can use any of the `PubSubPublisher` methods to send messages to Pub/Su
 ```scala mdoc:silent
 // Producing a single message
 
-publisher.publishOne("message")
+publisher.flatMap(_.publishOne("message"))
 ```
 
 ```scala mdoc:silent
@@ -73,13 +73,13 @@ val records = List(
    PubSubRecord.Publisher("message3")
 )
 
-publisher.publishMany(records)
+publisher.flatMap(_.publishMany(records))
 ```
 
 ```scala mdoc:silent
 // Producing a message with attributes
 
-publisher.publishOne("message", "key" -> "value")
+publisher.flatMap(_.publishOne("message", "key" -> "value"))
 ```
 
 ```scala mdoc:silent
@@ -87,7 +87,7 @@ publisher.publishOne("message", "key" -> "value")
 
 val record = PubSubRecord.Publisher("message").withAttribute("key", "value")
 
-publisher.publishOne(record)
+publisher.flatMap(_.publishOne(record))
 ```
 
 #### Configuring the publisher
@@ -123,11 +123,12 @@ You can create an instance of this class from a regular `PubSubPublisher` by usi
 import cats.effect.Resource
 import scala.concurrent.duration._
 
-val asyncPublisher: Resource[IO, PubSubPublisher.Async[IO, String]] = 
-   publisher
-    .batching
-    .batchSize(10)
-    .maxLatency(1.second)
+val asyncPublisher: Resource[IO, PubSubPublisher.Async[IO, String]] =
+   Resource.eval(publisher).flatMap(
+    _.batching
+      .batchSize(10)
+      .maxLatency(1.second)
+   )
 ```
 
 Then you can use any of the `PubSubPublisher.Async` methods to send messages to Pub/Sub.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion           := "2.13.18"
 ThisBuild / crossScalaVersions     := Seq("2.13.18", "3.3.7")
 ThisBuild / organization           := "com.permutive"
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; publishLocal; +test")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")

--- a/modules/fs2-pubsub/src/main/scala/fs2/pubsub/PubSubClient.scala
+++ b/modules/fs2-pubsub/src/main/scala/fs2/pubsub/PubSubClient.scala
@@ -21,6 +21,7 @@ import java.util.Base64
 
 import scala.util.control.NonFatal
 
+import cats.Functor
 import cats.effect.Temporal
 import cats.syntax.all._
 
@@ -38,6 +39,8 @@ import fs2.pubsub.dsl.client.PubSubClientStep
 import fs2.pubsub.dsl.client._
 import fs2.pubsub.exceptions.PubSubRequestError
 import fs2.pubsub.grpc.internal.AcknowledgeRequest
+import fs2.pubsub.grpc.internal.GetSubscriptionRequest
+import fs2.pubsub.grpc.internal.GetTopicRequest
 import fs2.pubsub.grpc.internal.ModifyAckDeadlineRequest
 import fs2.pubsub.grpc.internal.PublishRequest
 import fs2.pubsub.grpc.internal.Publisher
@@ -148,6 +151,21 @@ trait PubSubClient[F[_]] {
     */
   def modifyDeadline(subscription: Subscription, ackIds: Chunk[AckId], by: AckDeadline): F[Unit]
 
+  /** Verifies that the topic exists and is accessible with the current credentials. Raises an error in `F` on failure.
+    *
+    * @param topic
+    *   the topic to check
+    */
+  def checkTopic(topic: Topic): F[Unit]
+
+  /** Verifies that the subscription exists and is accessible with the current credentials. Raises an error in `F` on
+    * failure.
+    *
+    * @param subscription
+    *   the subscription to check
+    */
+  def checkSubscription(subscription: Subscription): F[Unit]
+
   /** Returns a `PubSubPublisher.Builder` to configure and create a publisher for a specific message type within
     * Pub/Sub.
     *
@@ -156,7 +174,7 @@ trait PubSubClient[F[_]] {
     * @return
     *   a `PubSubPublisher.Builder` instance for the specified message type
     */
-  def publisher[A: MessageEncoder]: PubSubPublisher.Builder.FromPubSubClient[F, A] =
+  def publisher[A: MessageEncoder](implicit F: Functor[F]): PubSubPublisher.Builder.FromPubSubClient[F, A] =
     PubSubPublisher.fromPubSubClient(this)
 
   /** Returns a `PubSubSubscriber.Builder` to configure and create a subscriber for handling messages within Pub/Sub. */
@@ -317,6 +335,30 @@ object PubSubClient {
           }
       }
 
+      override def checkTopic(topic: Topic): F[Unit] = {
+        val request = GET(uri / "v1" / "projects" / projectId / "topics" / show"$topic")
+
+        httpClient
+          .expectOr[Unit](request)(PubSubRequestError.from(_, request).widen)
+          .void
+          .adaptError {
+            case e: PubSubRequestError => e
+            case NonFatal(e)           => PubSubRequestError("Failed to check topic in PubSub", request, e)
+          }
+      }
+
+      override def checkSubscription(subscription: Subscription): F[Unit] = {
+        val request = GET(uri / "v1" / "projects" / projectId / "subscriptions" / show"$subscription")
+
+        httpClient
+          .expectOr[Unit](request)(PubSubRequestError.from(_, request).widen)
+          .void
+          .adaptError {
+            case e: PubSubRequestError => e
+            case NonFatal(e)           => PubSubRequestError("Failed to check subscription in PubSub", request, e)
+          }
+      }
+
     }
 
   }
@@ -404,6 +446,24 @@ object PubSubClient {
 
         subscriber
           .modifyAckDeadline(request, Headers.empty)
+          .void
+      }
+
+      override def checkTopic(topic: Topic): F[Unit] = {
+        val request = GetTopicRequest.of(topic = show"projects/$projectId/topics/$topic")
+
+        publisher
+          .getTopic(request, Headers.empty)
+          .void
+      }
+
+      override def checkSubscription(subscription: Subscription): F[Unit] = {
+        val request = GetSubscriptionRequest.of(
+          subscription = show"projects/$projectId/subscriptions/$subscription"
+        )
+
+        subscriber
+          .getSubscription(request, Headers.empty)
           .void
       }
 

--- a/modules/fs2-pubsub/src/main/scala/fs2/pubsub/PubSubPublisher.scala
+++ b/modules/fs2-pubsub/src/main/scala/fs2/pubsub/PubSubPublisher.scala
@@ -185,16 +185,19 @@ object PubSubPublisher {
     * @return
     *   a builder instance sourcing configuration from the provided `PubSubClient`
     */
-  def fromPubSubClient[F[_], A: MessageEncoder](pubSubClient: PubSubClient[F]): Builder.FromPubSubClient[F, A] =
-    topic => records => pubSubClient.publish[A](topic, records)
+  def fromPubSubClient[F[_]: Functor, A: MessageEncoder](
+      pubSubClient: PubSubClient[F]
+  ): Builder.FromPubSubClient[F, A] =
+    topic => pubSubClient.checkTopic(topic).as(pubSubClient.publish[A](topic, _))
 
   object Builder {
 
-    type Default[F[_], A] = ProjectIdStep[TopicStep[UriStep[ClientStep[F, RetryPolicyStep[F, PubSubPublisher[F, A]]]]]]
+    type Default[F[_], A] =
+      ProjectIdStep[TopicStep[UriStep[ClientStep[F, RetryPolicyStep[F, F[PubSubPublisher[F, A]]]]]]]
 
-    type FromConfig[F[_], A] = ClientStep[F, RetryPolicyStep[F, PubSubPublisher[F, A]]]
+    type FromConfig[F[_], A] = ClientStep[F, RetryPolicyStep[F, F[PubSubPublisher[F, A]]]]
 
-    type FromPubSubClient[F[_], A] = TopicStep[PubSubPublisher[F, A]]
+    type FromPubSubClient[F[_], A] = TopicStep[F[PubSubPublisher[F, A]]]
 
   }
 

--- a/modules/fs2-pubsub/src/main/scala/fs2/pubsub/PubSubSubscriber.scala
+++ b/modules/fs2-pubsub/src/main/scala/fs2/pubsub/PubSubSubscriber.scala
@@ -176,7 +176,7 @@ object PubSubSubscriber {
               .map { case (channel, fiber) => (channel, channel.close.void >> fiber.join.void) }
           })
 
-        val stream = for {
+        val stream = Stream.eval(pubSubClient.checkSubscription(subscription)) >> (for {
           ack <- ackChannel { ackIds =>
                    pubSubClient
                      .ack(subscription, ackIds)
@@ -206,7 +206,7 @@ object PubSubSubscriber {
               .flatMap(Stream.emits)
 
           ackId = record.ackId
-        } yield record.withAck(ack.send(ackId).void).withNack(nack.send(ackId).void)
+        } yield record.withAck(ack.send(ackId).void).withNack(nack.send(ackId).void))
 
         SubscriberStep(stream, errorHandler)
   }

--- a/modules/fs2-pubsub/src/main/scala/fs2/pubsub/dsl/publisher.scala
+++ b/modules/fs2-pubsub/src/main/scala/fs2/pubsub/dsl/publisher.scala
@@ -19,6 +19,7 @@ package fs2.pubsub.dsl
 import scala.concurrent.duration.FiniteDuration
 
 import cats.effect.Temporal
+import cats.effect.syntax.all._
 
 import fs2.pubsub.MessageEncoder
 import fs2.pubsub.PubSubPublisher
@@ -76,9 +77,8 @@ object publisher {
         .uri(config.uri)
         .httpClient(client)
         .retryPolicy(retryPolicy)
-        .batching
-        .batchSize(config.batchSize)
-        .maxLatency(config.maxLatency)
+        .toResource
+        .flatMap(_.batching.batchSize(config.batchSize).maxLatency(config.maxLatency))
     }
 
   }

--- a/modules/fs2-pubsub/src/test/scala/fs2/pubsub/PubSubPublisherSuite.scala
+++ b/modules/fs2-pubsub/src/test/scala/fs2/pubsub/PubSubPublisherSuite.scala
@@ -43,7 +43,7 @@ class PubSubPublisherSuite extends FunSuite {
       .httpClient(client)
       .noRetry
 
-    assert(publisher.isInstanceOf[PubSubPublisher[IO, String]])
+    assert(publisher.isInstanceOf[IO[PubSubPublisher[IO, String]]])
   }
 
   test("PubSubPublisher.Async can be created from configuration class") {

--- a/modules/fs2-pubsub/src/test/scala/fs2/pubsub/PubSubSuite.scala
+++ b/modules/fs2-pubsub/src/test/scala/fs2/pubsub/PubSubSuite.scala
@@ -102,9 +102,82 @@ class PubSubSuite extends CatsEffectSuite {
       }
   }
 
+  options.foreach { case (clientType, constructor) =>
+    withPubSubClient(constructor)
+      .test(s"$clientType - checkTopic succeeds for an existing topic") { pubSubClient =>
+        pubSubClient.checkTopic(Topic("example-topic"))
+      }
+
+    withPubSubClient(constructor)
+      .test(s"$clientType - checkTopic fails for a non-existent topic") { pubSubClient =>
+        interceptIO[Throwable](pubSubClient.checkTopic(Topic("nonexistent-topic")))
+      }
+
+    withPubSubClient(constructor)
+      .test(s"$clientType - checkSubscription succeeds for an existing subscription") { pubSubClient =>
+        pubSubClient.checkSubscription(Subscription("example-subscription"))
+      }
+
+    withPubSubClient(constructor)
+      .test(s"$clientType - checkSubscription fails for a non-existent subscription") { pubSubClient =>
+        interceptIO[Throwable](pubSubClient.checkSubscription(Subscription("nonexistent-subscription")))
+      }
+
+    withPubSubClient(constructor)
+      .test(s"$clientType - async publisher Resource fails to allocate for a non-existent topic") { pubSubClient =>
+        val resource = Resource
+          .eval(pubSubClient.publisher[String].topic(Topic("nonexistent-topic")))
+          .flatMap(_.batching.batchSize(10).maxLatency(1.second))
+
+        interceptIO[Throwable](resource.use_.timeout(5.seconds))
+      }
+
+    withPubSubClient(constructor)
+      .test(s"$clientType - subscriber stream fails for a non-existent subscription") { pubSubClient =>
+        val stream = pubSubClient.subscriber
+          .subscription(Subscription("nonexistent-subscription"))
+          .noErrorHandling
+          .withDefaults
+          .raw
+
+        interceptIO[Throwable](stream.compile.drain.timeout(5.seconds))
+      }
+  }
+
   //////////////
   // Fixtures //
   //////////////
+
+  def withPubSubClient(constructor: PubSubClientStep[IO]) =
+    ResourceFunFixture {
+      val projectId = ProjectId("test-project")
+
+      Resource.fromAutoCloseable(IO(container).flatTap(container => IO(container.start()))) >>
+        EmberClientBuilder
+          .default[IO]
+          .withHttp2
+          .build
+          .evalTap { client =>
+            val body = Json.obj(
+              "topic"              := "projects/test-project/topics/example-topic",
+              "ackDeadlineSeconds" := 10
+            )
+
+            val requests = List(
+              PUT(container.uri / "v1" / "projects" / projectId / "topics" / "example-topic"),
+              PUT(body, container.uri / "v1" / "projects" / projectId / "subscriptions" / "example-subscription")
+            )
+
+            requests.traverse_(client.expect[Unit])
+          }
+          .map { client =>
+            constructor
+              .projectId(projectId)
+              .uri(container.uri)
+              .httpClient(client)
+              .noRetry
+          }
+    }
 
   def afterProducing(constructor: PubSubClientStep[IO], records: Int, withAckDeadlineSeconds: Int = 10) =
     ResourceFunFixture {
@@ -128,29 +201,30 @@ class PubSubSuite extends CatsEffectSuite {
 
             requests.traverse_(client.expect[Unit])
           }
-          .map { client =>
+          .evalMap { client =>
             val pubSubClient = constructor
               .projectId(projectId)
               .uri(container.uri)
               .httpClient(client)
               .noRetry
 
-            val publisher = pubSubClient
+            pubSubClient
               .publisher[String]
               .topic(Topic("example-topic"))
+              .map { publisher =>
+                val subscriber = pubSubClient.subscriber
+                  .subscription(Subscription("example-subscription"))
+                  .errorHandler {
+                    case (PubSubSubscriber.Operation.Ack(_), t)         => IO.println(t)
+                    case (PubSubSubscriber.Operation.Nack(_), t)        => IO.println(t)
+                    case (PubSubSubscriber.Operation.Decode(record), t) => IO.println(t) >> record.ack
+                  }
+                  .withDefaults
+                  .decodeTo[String]
+                  .subscribe
 
-            val subscriber = pubSubClient.subscriber
-              .subscription(Subscription("example-subscription"))
-              .errorHandler {
-                case (PubSubSubscriber.Operation.Ack(_), t)         => IO.println(t)
-                case (PubSubSubscriber.Operation.Nack(_), t)        => IO.println(t)
-                case (PubSubSubscriber.Operation.Decode(record), t) => IO.println(t) >> record.ack
+                (publisher, subscriber)
               }
-              .withDefaults
-              .decodeTo[String]
-              .subscribe
-
-            (publisher, subscriber)
           }
           .evalTap {
             case (publisher, _) if records === 1 => publisher.publishOne("ping")


### PR DESCRIPTION
## :computer: How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## :rocket: What's included in this PR?

### Changes

- **Add `checkTopic`/`checkSubscription` abstract methods to `PubSubClient`** with HTTP and gRPC implementations. These verify that topics/subscriptions exist and are accessible with the current credentials.
- **Make publisher creation effectful** (`F[PubSubPublisher[F, A]]`) — calling `.topic(myTopic)` now runs `checkTopic` before returning the publisher. This ensures all publishers (sync and async) validate eagerly at creation time.
- **Wire subscription validation into subscriber streams** — `Stream.eval(checkSubscription(...))` is prepended so streams fail fast on the first pull if the subscription is invalid.
- **Add integration tests** for both HTTP and gRPC: `checkTopic`, `checkSubscription`, async publisher allocation failure, and subscriber stream failure.
- **Update documentation** to reflect the new effectful publisher type.

### Breaking changes

- `PubSubClient` has two new abstract methods: `checkTopic` and `checkSubscription`
- Publisher creation now returns `F[PubSubPublisher[F, A]]` instead of `PubSubPublisher[F, A]`
- `versionPolicyIntention` set to `Compatibility.None`